### PR TITLE
Allow Redis UNIX domain sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following attributes can be set using the `REDIS_URL`
 * port
 * key prefix
 
-For example, `export REDIS_URL=redis://passwd@192.168.0.1:16379/prefix` would
+For example, `export REDIS_URL=redis://:passwd@192.168.0.1:16379/prefix` would
 authenticate with `password`, connecting to 192.168.0.1 on port 16379, and store
 data using the `prefix:storage` key.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ The following attributes can be set using the `REDIS_URL`
 * port
 * key prefix
 
-For example, `export REDIS_URL=redis://:passwd@192.168.0.1:16379/prefix` would
-authenticate with `password`, connecting to 192.168.0.1 on port 16379, and store
+For example, `export REDIS_URL=redis://:password@192.168.0.1:16379/prefix` would
+authenticate with `password`, connecting to `192.168.0.1` on port `16379`, and store
 data using the `prefix:storage` key.
+
+For a UNIX domain socket, `export REDIS_URL=redis://:password@/var/run/redis.sock?prefix` would authenticate with `password`, connecting to `/var/run/redis.sock`, and store data using the `prefix:storage` key.
 
 ### Installing your own
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/hubot-scripts/hubot-redis-brain/issues"
   },
   "dependencies": {
-    "redis": "0.8.4"
+    "redis": "~0.12.x"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -35,8 +35,8 @@ module.exports = (robot) ->
 
 
   info   = Url.parse  redisUrl, true
-  client = Redis.createClient(info.port, info.hostname)
-  prefix = info.path?.replace('/', '') or 'hubot'
+  client = if info.hostname == '' then Redis.createClient(info.pathname) else Redis.createClient(info.port, info.hostname)
+  prefix = if info.hostname == '' then 'hubot' else info.path?.replace('/', '')
 
   robot.brain.setAutoSave false
 

--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -4,6 +4,7 @@
 # Configuration:
 #   REDISTOGO_URL or REDISCLOUD_URL or BOXEN_REDIS_URL or REDIS_URL.
 #   URL format: redis://<host>:<port>[/<brain_prefix>]
+#   URL format (UNIX socket): redis://<socketpath>[?<brain_prefix>]
 #   If not provided, '<brain_prefix>' will default to 'hubot'.
 #
 # Commands:
@@ -34,9 +35,13 @@ module.exports = (robot) ->
     robot.logger.info "Using default redis on localhost:6379"
 
 
-  info   = Url.parse  redisUrl, true
-  client = if info.hostname == '' then Redis.createClient(info.pathname) else Redis.createClient(info.port, info.hostname)
-  prefix = if info.hostname == '' then 'hubot' else info.path?.replace('/', '')
+  info = Url.parse  redisUrl, true
+  if info.hostname == ''
+    client = Redis.createClient(info.pathname)
+    prefix = info.query?.toString() or 'hubot'
+  else
+    client = Redis.createClient(info.port, info.hostname)
+    prefix = info.pathname?.replace('/', '') or info.query?.toString() or 'hubot'
 
   robot.brain.setAutoSave false
 


### PR DESCRIPTION
The older version of the `redis` module didn't support UNIX domain sockets.

It appears authentication was already present, but the README didn't mention a `colon` was required before the password.
