### PR TITLE
adding support for docker linking

### DIFF
--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -25,6 +25,9 @@ module.exports = (robot) ->
              else if process.env.REDIS_URL?
                redisUrlEnv = "REDIS_URL"
                process.env.REDIS_URL
+             else if process.env.BRAIN_PORT_6379_TCP_ADDR? && process.env.BRAIN_PORT_6379_TCP_PORT?
+               redisUrlEnv = "redis://BRAIN_PORT_6379_TCP_ADDR:BRAIN_PORT_6379_TCP_PORT"
+               "redis://" + process.env.BRAIN_PORT_6379_TCP_ADDR + ":" + process.env.BRAIN_PORT_6379_TCP_PORT
              else
                'redis://localhost:6379'
 


### PR DESCRIPTION
This patch uses linking environment variables provided by docker and allow you to run hubot and redis in docker.
The redis instance has to be aliased as 'brain'

start a persistent redis brain
`docker run --name hubot_brain -d redis  redis-server --appendonly yes`

then start your hubot image
`docker run -d --link hubot_brain:brain your_hubot_image`
