### PR TITLE
Redis-Brain connected Event

### DIFF
--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -47,9 +47,11 @@ module.exports = (robot) ->
       else if reply
         robot.logger.info "hubot-redis-brain: Data for #{prefix} brain retrieved from Redis"
         robot.brain.mergeData JSON.parse(reply.toString())
+        robot.emit "redis-brain-connected"
       else
         robot.logger.info "hubot-redis-brain: Initializing new data for #{prefix} brain"
         robot.brain.mergeData {}
+        robot.emit "redis-brain-connected"
 
       robot.brain.setAutoSave true
 


### PR DESCRIPTION
Some scripts will want to do start-up actions that will involve Redis to already be loaded with data to then be executed.

I've added an event that will be triggered once Redis is loaded for hubot and any other script listening on that event will trigger the other events necessary for other scripts.
