### PR TITLE
Add ability to turn off Redis Ready check when INFO is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ run your own, most package managers have a package for redis:
 If you are using [boxen](https://boxen.github.com/) to manage your environment,
 hubot-redis-brain will automatically use the boxen-managed redis (ie by using `BOXEN_REDIS_URL`).
 
-
 ### Heroku
 
 If you are deploying on [Heroku](https://www.heroku.com/), you can add the
@@ -61,3 +60,10 @@ Redis Cloud or Redis To Go addon to have automatically configure itself to use i
 Other redis addons would need to be configured using `REDIS_URL` until support
 is added to hubot-redis-brain (or hubot-redis-brain needs to be updated to look
   for the environment variable the service uses)
+
+### Redis Twemproxy
+
+If you are using [Twemproxy](https://github.com/twitter/twemproxy) to cluster redis,
+you need to turn off the redis ready check which uses the unsupported INFO cmd.
+
+`REDIS_NO_CHECK = 1`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-redis-brain",
   "description": "A hubot script to persist hubot's brain using redis",
-  "version": "0.0.3",
+  "version": "0.0.3-gsg",
   "author": "Josh Nichols <technicalpickles@github.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-redis-brain",
   "description": "A hubot script to persist hubot's brain using redis",
-  "version": "0.0.3-gsg",
+  "version": "0.0.3",
   "author": "Josh Nichols <technicalpickles@github.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",

--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -43,7 +43,6 @@ module.exports = (robot) ->
 
   info   = Url.parse redisUrl, true
   client = if info.auth or redisNoCheck == 'Y'
-          then
             Redis.createClient(info.port, info.hostname, {no_ready_check: true})
           else
             Redis.createClient(info.port, info.hostname)

--- a/src/redis-brain.coffee
+++ b/src/redis-brain.coffee
@@ -28,14 +28,25 @@ module.exports = (robot) ->
              else
                'redis://localhost:6379'
 
+  redisNoCheck = if process.env.REDIS_NO_CHECK?
+                   'Y'
+                 else
+                   'N'                   
+
   if redisUrlEnv?
     robot.logger.info "hubot-redis-brain: Discovered redis from #{redisUrlEnv} environment variable"
   else
     robot.logger.info "hubot-redis-brain: Using default redis on localhost:6379"
 
+  if redisNoCheck?
+    robot.logger.info "Turning off redis ready checks"
 
   info   = Url.parse redisUrl, true
-  client = if info.auth then Redis.createClient(info.port, info.hostname, {no_ready_check: true}) else Redis.createClient(info.port, info.hostname)
+  client = if info.auth or redisNoCheck == 'Y'
+          then
+            Redis.createClient(info.port, info.hostname, {no_ready_check: true})
+          else
+            Redis.createClient(info.port, info.hostname)
   prefix = info.path?.replace('/', '') or 'hubot'
 
   robot.brain.setAutoSave false


### PR DESCRIPTION
Add ability to turn off Redis Ready check when INFO is not available.

When using against a redis cluster using TWEMProxy, the INFO command is not available.   The redis connection need to not check for Redis Ready without resorting to authentication.

This PR adds support for environment variable `REDIS_NO_CHECK` to turn off the check.