### PR TITLE
Add basic support for CloudFoundry Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Redis Cloud or Redis To Go addon to have automatically configure itself to use i
 * [Redis Cloud](https://addons.heroku.com/rediscloud)
 * [Redis To Go](https://addons.heroku.com/redistogo)
 
+### CloudFoundry
+
+If you are deploying in a CloudFoundry environment, you can use any redis service available in your marketplace.
+
+You'll need to set two environment variables in this case: 
+`CF_REDIS_SERVICE` - Your CloudFoundry's Redis Service name (ie. p-redis or rediscloud) 
+`CF_REDIS_INSTANCE_NAME` - The name you gave your serive instance. This will be used as the brain_prefix 
+
+### Other
 
 Other redis addons would need to be configured using `REDIS_URL` until support
 is added to hubot-redis-brain (or hubot-redis-brain needs to be updated to look

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you are deploying in a CloudFoundry environment, you can use any redis servic
 
 You'll need to set two environment variables in this case: 
 `CF_REDIS_SERVICE` - Your CloudFoundry's Redis Service name (ie. p-redis or rediscloud) 
-`CF_REDIS_INSTANCE_NAME` - The name you gave your serive instance. This will be used as the brain_prefix 
+`CF_REDIS_INSTANCE_NAME` - The name you gave your service instance. This will be used as the brain_prefix 
 
 ### Other
 

--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -136,11 +136,21 @@ function buildCloudFoundryURL () {
     services = process.env.VCAP_SERVICES
   }
   const redisService = services[process.env.CF_REDIS_SERVICE]
-  for (let instance of redisService) {
-    if (instance['name'] === process.env.CF_REDIS_INSTANCE_NAME) {
-      hubotInstance = instance
-      break
+  const instanceName = process.env.CF_REDIS_INSTANCE_NAME || none
+  if (instanceName){
+    for (let instance of redisService) {
+      if (instance['name'] === instanceName) {
+        hubotInstance = instance
+        break
+      }
     }
+    if (!hubotInstance) {
+      robot.logger.info('Could not find redis instance; reverting to localhost')
+      return 'redis://localhost:6379'
+    }
+  } else {
+    robot.logger.info('CF_REDIS_INSTANCE_NAME environment variable not set; reverting to localhost')
+    return 'redis://localhost:6379'
   }
   const redisCreds = hubotInstance['credentials']
   if (redisCreds['hostname'] === undefined) {

--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -129,7 +129,12 @@ function getRedisEnv () {
 
 function buildCloudFoundryURL () {
   let host, hubotInstance
-  const services = JSON.parse(process.env.VCAP_SERVICES)
+  let services
+  try {
+    services = JSON.parse(process.env.VCAP_SERVICES)
+  } catch (e) {
+    services = process.env.VCAP_SERVICES
+  }
   const redisService = services[process.env.CF_REDIS_SERVICE]
   for (let instance of redisService) {
     if (instance['name'] === process.env.CF_REDIS_INSTANCE_NAME) {

--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -11,7 +11,7 @@
 //   REDIS_NO_CHECK - set this to avoid ready check (for exampel when using Twemproxy)
 //   # CloudFoundry Vars (Use the following vars only for running in CF)
 //   CF_REDIS_SERVICE - Your CloudFoundry's Redis Service name (ie. p-redis or rediscloud)
-//   CF_REDIS_INSTANCE_NAME = The name you gave your serive instance. This will be used as the brain_prefix
+//   CF_REDIS_INSTANCE_NAME = The name you gave your service instance. This will be used as the brain_prefix
 //
 // Commands:
 //   None

--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -26,7 +26,7 @@ module.exports = function (robot) {
   if (redisUrlEnv) {
     if (redisUrlEnv === 'CF_REDIS_INSTANCE_NAME') {
       robot.logger.info(`hubot-redis-brain: Discovered redis from ${redisUrlEnv} environment variable. Pulling from VCAP`)
-      redisUrl = buildCloudFoundryURL()
+      redisUrl = buildCloudFoundryURL(robot)
     } else {
       robot.logger.info(`hubot-redis-brain: Discovered redis from ${redisUrlEnv} environment variable`)
       redisUrl = process.env[redisUrlEnv]
@@ -127,7 +127,7 @@ function getRedisEnv () {
   }
 }
 
-function buildCloudFoundryURL () {
+function buildCloudFoundryURL (robot) {
   let host, hubotInstance
   let services
   try {
@@ -136,8 +136,8 @@ function buildCloudFoundryURL () {
     services = process.env.VCAP_SERVICES
   }
   const redisService = services[process.env.CF_REDIS_SERVICE]
-  const instanceName = process.env.CF_REDIS_INSTANCE_NAME || none
-  if (instanceName){
+  const instanceName = process.env.CF_REDIS_INSTANCE_NAME || null
+  if (instanceName) {
     for (let instance of redisService) {
       if (instance['name'] === instanceName) {
         hubotInstance = instance


### PR DESCRIPTION
CloudFoundry automatically injects Redis info into apps via the VCAP_SERVICES environment variable. I've added code to use that env var when a user adds info about the service they chose and uses the name of the service as the Redis prefix. 

I've added documentation for what env vars to set, as well as a test to check the call that uses the CF env vars.

I believe I've followed best practices, but if you notice something off, let me know and I can fix it. 😄 