### PR TITLE
Bump Redis version for security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/hubotio/hubot-redis-brain/issues"
   },
   "dependencies": {
-    "redis": "^2.7.1"
+    "redis": "^3.1.1"
   },
   "peerDependencies": {
     "hubot": ">=2 <10 || 0.0.0-development"


### PR DESCRIPTION
Security fix pushed out in https://github.com/NodeRedis/node-redis/commit/2d11b6dc9b9774464a91fb4b448bad8bf699629e