### PR TITLE
fix: Use `pathname` field instead of `path` field

### DIFF
--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -39,7 +39,7 @@ module.exports = function (robot) {
     client = (info.auth || process.env.REDIS_NO_CHECK)
       ? Redis.createClient(info.port, info.hostname, { no_ready_check: true })
       : Redis.createClient(info.port, info.hostname)
-    prefix = (info.path ? info.path.replace('/', '') : undefined) || 'hubot'
+    prefix = (info.pathname ? info.pathname.replace('/', '') : undefined) || 'hubot'
   }
 
   robot.brain.setAutoSave(false)


### PR DESCRIPTION
Since [the change from `Url.parse` to `URL`](https://github.com/hubotio/hubot-redis-brain/commit/25d0249e080c881509d17b74f8c67083703de866), the `path` field has been removed from the `info` object.