### PR TITLE
fix: Error when using string key prefix as part of REDIS_URL

### DIFF
--- a/src/redis-brain.js
+++ b/src/redis-brain.js
@@ -32,19 +32,24 @@ module.exports = function (robot, redis = Redis) {
 
   let info = null
   let prefix = ''
+  let database = null
   try {
     info = new URL(redisUrl)
-    prefix = (info.pathname ? info.pathname.replace('/', '') : undefined) || 'hubot'
+    database = Number((info.pathname ? info.pathname.replace('/', '') : undefined) || 0)
   } catch (err) {
     if (err.code === 'ERR_INVALID_URL') {
       const urlPath = redisUrl.replace(/rediss?:\/{2}:?(.*@)?/, '')
       info = new URL(`redis://${urlPath}`)
-      prefix = info.search?.replace('?', '') || 'hubot'
     }
   }
+  prefix = info.search?.replace('?', '') || 'hubot'
 
   let redisOptions = {
     url: redisUrl
+  }
+
+  if (database) {
+    redisOptions = Object.assign(redisOptions || {}, { database })
   }
 
   let redisSocket = null

--- a/test/redis-brain-test.js
+++ b/test/redis-brain-test.js
@@ -110,8 +110,8 @@ describe('redis-brain', () => {
     delete process.env.REDIS_NO_CHECK
   })
 
-  it('Setting the prefix with redis://localhost:6379/prefix-for-redis-key', () => {
-    process.env.REDIS_URL = 'redis://localhost:6379/prefix-for-redis-key'
+  it('Setting the prefix with redis://localhost:6379/1?prefix-for-redis-key', () => {
+    process.env.REDIS_URL = 'redis://localhost:6379/1?prefix-for-redis-key'
     const robot = new Robot(null, 'shell', false, 'hubot')
     const delegate = {
       data: {},
@@ -124,6 +124,49 @@ describe('redis-brain', () => {
     }
     redisBrain(robot, {
       createClient: (options) => {
+        expect(options.database).to.equal(1)
+        return new RedisMock(delegate)
+      }
+    })
+    robot.run()
+  })
+
+  it('Setting the prefix with no database number specified redis://localhost?prefix-for-redis-key', () => {
+    process.env.REDIS_URL = 'redis://localhost?prefix-for-redis-key'
+    const robot = new Robot(null, 'shell', false, 'hubot')
+    const delegate = {
+      data: {},
+      async get (key) {
+        expect(key).to.equal('prefix-for-redis-key:storage')
+        robot.shutdown()
+        delete process.env.REDIS_URL
+        return this.data[key]
+      }
+    }
+    redisBrain(robot, {
+      createClient: (options) => {
+        expect(options.database).to.be.undefined
+        return new RedisMock(delegate)
+      }
+    })
+    robot.run()
+  })
+
+  it('Setting the prefix with no database number specified and a trailing slash redis://localhost:6379/?prefix-for-redis-key', () => {
+    process.env.REDIS_URL = 'redis://localhost:6379/?prefix-for-redis-key'
+    const robot = new Robot(null, 'shell', false, 'hubot')
+    const delegate = {
+      data: {},
+      async get (key) {
+        expect(key).to.equal('prefix-for-redis-key:storage')
+        robot.shutdown()
+        delete process.env.REDIS_URL
+        return this.data[key]
+      }
+    }
+    redisBrain(robot, {
+      createClient: (options) => {
+        expect(options.database).to.be.undefined
         return new RedisMock(delegate)
       }
     })
@@ -144,6 +187,7 @@ describe('redis-brain', () => {
     }
     redisBrain(robot, {
       createClient: (options) => {
+        expect(options.database).to.be.undefined
         return new RedisMock(delegate)
       }
     })


### PR DESCRIPTION
BREAKING CHANGE: REDIS_URL should have the database number as the pathname instead of the prefix.

Example setting the key prefix via Redis URL: redis://localhost:6379/?prefix-for-redis-key or redis://localhost:6379?prefix-for-redis-key

fixes #58 